### PR TITLE
Remove comments before and after inserted JS

### DIFF
--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -264,12 +264,10 @@ EOT;
     // perform the final eval().
     $js = <<<EOT
 <span id="$name">$msg</span><script id="script_{$name}" type="text/javascript">
-/* <!-- */
 function hivelogic_$name() {
 var kode="$clean",i,c,x,script=document.currentScript||document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script&&script.parentNode.removeChild(script);
 }
 hivelogic_$name();
-/* --> */
 </script>
 EOT;
 


### PR DESCRIPTION
- No longer necessary in modern browsers
- Ensures the enkoder still works when used with scripts that compact source code and strip out comments